### PR TITLE
Remove Big Threads news letter feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 /1.6/Source/MedievalOverhaulRoyalty/.vs
 /1.6/Source/MedievalOverhaulRoyalty/obj
+/1.6/Assemblies/MedievalOverhaulRoyalty/.vs
+/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty/bin
+/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty/obj
 *.pdb
 1.6/Assemblies/MedievalOverhaul.dll

--- a/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty.sln
+++ b/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33213.308
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MedievalOverhaulRoyalty", "MedievalOverhaulRoyalty\MedievalOverhaulRoyalty.csproj", "{DC3E22A5-7E62-41DC-9814-48823E16A7D7}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{DC3E22A5-7E62-41DC-9814-48823E16A7D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DC3E22A5-7E62-41DC-9814-48823E16A7D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DC3E22A5-7E62-41DC-9814-48823E16A7D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DC3E22A5-7E62-41DC-9814-48823E16A7D7}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BF7123FD-0B50-49C7-8583-3F41ACF91980}
+	EndGlobalSection
+EndGlobal

--- a/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty.csproj
+++ b/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DC3E22A5-7E62-41DC-9814-48823E16A7D7}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MedievalOverhaulRoyalty</RootNamespace>
+    <AssemblyName>MedievalOverhaulRoyalty</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="MedievalOverhaulRoyalty_Mod.cs" />
+    <Compile Include="MedievalOverhaulRoyalty_ModSettings.cs" />
+    <Compile Include="PatchOperation_ToggleSettings.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>..\..\..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty_Mod.cs
+++ b/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty_Mod.cs
@@ -1,0 +1,56 @@
+﻿using UnityEngine;
+using Verse;
+using RimWorld;
+
+namespace MedievalOverhaulRoyalty
+{
+    public class MedievalOverhaulRoyalty_Mod : Mod
+    {
+        private MedievalOverhaulRoyalty_ModSettings settings;
+
+        public MedievalOverhaulRoyalty_Mod(ModContentPack content) : base(content)
+        {
+            settings = GetSettings<MedievalOverhaulRoyalty_ModSettings>();
+        }
+
+        public override void DoSettingsWindowContents(Rect inRect)
+        {
+            Listing_Standard list = new Listing_Standard();
+            list.Begin(inRect);
+
+            DrawToggleSetting(list, "EEG_RoyaltyTitle");
+            list.GapLine();
+            DrawToggleSetting(list, "EEG_RoyaltyTrader");
+
+            list.End();
+        }
+
+        private void DrawToggleSetting(Listing_Standard list, string key)
+        {
+            bool enabled = MedievalOverhaulRoyalty_ModSettings.enabledSettings.Contains(key);
+
+            string label = (key + "_Label").Translate();
+            string desc = (key + "_Desc").Translate();
+
+            Text.Font = GameFont.Medium;
+            list.CheckboxLabeled(label, ref enabled);
+            Text.Font = GameFont.Small;
+
+            if (!string.IsNullOrEmpty(desc))
+            {
+                list.Label(desc);
+                list.Gap(6f);
+            }
+
+            if (enabled)
+                MedievalOverhaulRoyalty_ModSettings.enabledSettings.Add(key);
+            else
+                MedievalOverhaulRoyalty_ModSettings.enabledSettings.Remove(key);
+        }
+
+        public override string SettingsCategory()
+        {
+            return "Medieval Overhaul Royalty";
+        }
+    }
+}

--- a/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty_ModSettings.cs
+++ b/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty_ModSettings.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using Verse;
+
+namespace MedievalOverhaulRoyalty
+{
+    public class MedievalOverhaulRoyalty_ModSettings : ModSettings
+    {
+        public static HashSet<string> enabledSettings = new HashSet<string>();
+
+        public override void ExposeData()
+        {
+            Scribe_Collections.Look(ref enabledSettings, "enabledSettings", LookMode.Value);
+            base.ExposeData();
+        }
+
+        public static bool IsEnabled(string key)
+        {
+            return enabledSettings.Contains(key);
+        }
+    }
+}

--- a/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty/PatchOperation_ToggleSettings.cs
+++ b/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty/PatchOperation_ToggleSettings.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Xml;
+using Verse;
+
+namespace MedievalOverhaulRoyalty
+{
+    public class PatchOperation_ToggleSettings : PatchOperation
+    {
+        public List<string> settings;
+        public PatchOperation active;
+        public PatchOperation inactive;
+
+        protected override bool ApplyWorker(XmlDocument xml)
+        {
+            bool anyActive = false;
+
+            foreach (var setting in settings)
+            {
+                if (MedievalOverhaulRoyalty_ModSettings.IsEnabled(setting))
+                {
+                    anyActive = true;
+                    break;
+                }
+            }
+
+            if (anyActive && active != null)
+            {
+                return active.Apply(xml);
+            }
+            else if (!anyActive && inactive != null)
+            {
+                return inactive.Apply(xml);
+            }
+
+            return true;
+        }
+    }
+}

--- a/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty/Properties/AssemblyInfo.cs
+++ b/1.6/Assemblies/MedievalOverhaulRoyalty/MedievalOverhaulRoyalty/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MedievalOverhaulRoyalty")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MedievalOverhaulRoyalty")]
+[assembly: AssemblyCopyright("Copyright ©  2025")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("dc3e22a5-7e62-41dc-9814-48823e16a7d7")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/1.6/Defs/LetterDefs/ModMenuNewsLetter.xml
+++ b/1.6/Defs/LetterDefs/ModMenuNewsLetter.xml
@@ -1,8 +1,0 @@
-<Defs>
-  <LetterDef ParentName="ThreatBig">
-    <defName>MOR_ModMenuNewsLetter</defName>
-    <label>MO:R</label>
-    <color>(1, 0.84, 0)</color>
-    <arriveSound>LetterArrive</arriveSound>
-  </LetterDef>
-</Defs>

--- a/Languages/English/Keyed/MOR_News.xml
+++ b/Languages/English/Keyed/MOR_News.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<LanguageData>
-  <MOR_ModMenuNewsLetter_Title>Medieval Overhaul Royalty - New Configuration Menu</MOR_ModMenuNewsLetter_Title>
-  <MOR_ModMenuNewsLetter_Text>Medieval Overhaul Royalty now features its own configuration menu in your Mod Options!\n\nAccess it anytime through:\nOptions → Mod Options → Medieval Overhaul Royalty\n\nTwo new settings are available:\n\n• Medieval Overhaul - Furniture Integration\nControls whether Medieval Overhaul items completely replace vanilla royal furniture, or are added as supplementary options.\n\n• Medieval Overhaul - Empire Trader Integration\nDetermine if Medieval Overhaul goods dominate Empire trader stocks, or are mixed with vanilla items (incl. orbital trader).\n\nConfigure these settings to your preference and reload your game to apply the changes!</MOR_ModMenuNewsLetter_Text>
-</LanguageData>

--- a/Languages/German/Keyed/MOR_News.xml
+++ b/Languages/German/Keyed/MOR_News.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<LanguageData>
-  <MOR_ModMenuNewsLetter_Title>Medieval Overhaul Royalty - Neues Konfigurationsmenü.</MOR_ModMenuNewsLetter_Title>
-  <MOR_ModMenuNewsLetter_Text>Medieval Overhaul Royalty verfügt jetzt über ein eigenes Konfigurationsmenü in den Mod-Optionen!\n\nDu erreichst es jederzeit unter:\nOptionen → Mod-Optionen → Medieval Overhaul Royalty\n\nZwei neue Einstellungen sind verfügbar:\n\n• Medieval Overhaul - Möbelintegration\nLegt fest, ob Medieval Overhaul-Möbel die vanilla königlichen Möbel vollständig ersetzen oder als ergänzende Optionen hinzugefügt werden.\n\n• Medieval Overhaul - Empire-Händlerintegration\nBestimmt, ob Medieval Overhaul-Güter die Bestände von Empire-Händlern dominieren oder mit Vanilla-Artikeln gemischt werden (inkl. orbitaler Händler).\n\nStelle diese Einstellungen nach Wunsch ein und lade dein Spiel neu, um die Änderungen anzuwenden!</MOR_ModMenuNewsLetter_Text>
-</LanguageData>


### PR DESCRIPTION
The mod-menu news letter (LetterDef inheriting from ThreatBig) was shown on
every LoadedGame/StartedNewGame because its "already shown" flag was stored
per-savegame instead of globally, so it reappeared in every save/new game.

Since the info is outdated and the mod now has its own settings menu, the
whole feature is removed rather than fixed:

- C# source: deleted Bootstrap.cs, MOR_Harmony.cs, MOR_Save.cs,
  MOR_ShowLetter.cs, MedievalOverhaulRoyalty_NewsLetter.cs (not restored).
  Harmony was only used by this feature, so the 0Harmony reference and the
  related Compile entries are dropped from the .csproj.
- XML: removed Defs/LetterDefs/ModMenuNewsLetter.xml.
- Languages: removed English + German MOR_News.xml keyed translations.
- Restored the remaining mod-settings source (Mod, ModSettings,
  PatchOperation_ToggleSettings, AssemblyInfo) so the project still compiles.
- gitignore: ignore build artifacts (bin/obj/.vs) at the source location.

NOTE: the shipped MedievalOverhaulRoyalty.dll must be recompiled to apply
this; the committed DLL still contains the old feature.

https://claude.ai/code/session_01LdNCeGjBCM3X99taTAKwsg