### PR TITLE
Royal titles: VFEE higher-rank furniture parity + Drape count fix

### DIFF
--- a/1.6/Mods/Royalty/Patches/RoyalTitles/Royalty_RoyalTitles_Empire.xml
+++ b/1.6/Mods/Royalty/Patches/RoyalTitles/Royalty_RoyalTitles_Empire.xml
@@ -115,29 +115,79 @@
 								</value>
 							</li>
 							
-							<li Class="PatchOperationConditional">
-								<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape"]</xpath>
-								<match Class="PatchOperationReplace">
-								<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape"]</xpath>
-									<value>
-										<li Class="RoomRequirement_ThingAnyOfCount">
-											<things>
-												<li>DankPyon_RusticRoomDivider1x2c</li>
-												<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
-												<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
-											</things>
-											<count>1</count>
-										</li>
-									</value>
-								</match>
-								<nomatch Class="PatchOperationAdd">
-									<xpath>//RoyalTitleDef/bedroomRequirements/li[contains(., "Drape")]/things</xpath>
-									<value>
-										<li>DankPyon_RusticRoomDivider1x2c</li>
-										<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
-										<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
-									</value>
-								</nomatch>
+							<!-- Drape -> medieval room dividers as ALTERNATIVE, preserving each rank's drape count
+							     (VFEE escalates Drape 1->2->4->6; the old blanket replace flattened all to 1) -->
+							<li Class="PatchOperationSequence">
+								<operations>
+									<li Class="PatchOperationConditional">
+										<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=1]</xpath>
+										<match Class="PatchOperationReplace">
+											<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=1]</xpath>
+											<value>
+												<li Class="RoomRequirement_ThingAnyOfCount">
+													<things>
+														<li>Drape</li>
+														<li>DankPyon_RusticRoomDivider1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
+													</things>
+													<count>1</count>
+												</li>
+											</value>
+										</match>
+									</li>
+									<li Class="PatchOperationConditional">
+										<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=2]</xpath>
+										<match Class="PatchOperationReplace">
+											<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=2]</xpath>
+											<value>
+												<li Class="RoomRequirement_ThingAnyOfCount">
+													<things>
+														<li>Drape</li>
+														<li>DankPyon_RusticRoomDivider1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
+													</things>
+													<count>2</count>
+												</li>
+											</value>
+										</match>
+									</li>
+									<li Class="PatchOperationConditional">
+										<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=4]</xpath>
+										<match Class="PatchOperationReplace">
+											<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=4]</xpath>
+											<value>
+												<li Class="RoomRequirement_ThingAnyOfCount">
+													<things>
+														<li>Drape</li>
+														<li>DankPyon_RusticRoomDivider1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
+													</things>
+													<count>4</count>
+												</li>
+											</value>
+										</match>
+									</li>
+									<li Class="PatchOperationConditional">
+										<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=6]</xpath>
+										<match Class="PatchOperationReplace">
+											<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=6]</xpath>
+											<value>
+												<li Class="RoomRequirement_ThingAnyOfCount">
+													<things>
+														<li>Drape</li>
+														<li>DankPyon_RusticRoomDivider1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
+													</things>
+													<count>6</count>
+												</li>
+											</value>
+										</match>
+									</li>
+								</operations>
 							</li>
 														
 							<li Class="PatchOperationAdd">
@@ -529,29 +579,79 @@
 								</value>
 							</li>
 							
-							<li Class="PatchOperationConditional">
-								<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape"]</xpath>
-								<match Class="PatchOperationReplace">
-								<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape"]</xpath>
-									<value>
-										<li Class="RoomRequirement_ThingAnyOfCount">
-											<things>
-												<li>DankPyon_RusticRoomDivider1x2c</li>
-												<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
-												<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
-											</things>
-											<count>1</count>
-										</li>
-									</value>
-								</match>
-								<nomatch Class="PatchOperationAdd">
-									<xpath>//RoyalTitleDef/bedroomRequirements/li[contains(., "Drape")]/things</xpath>
-									<value>
-										<li>DankPyon_RusticRoomDivider1x2c</li>
-										<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
-										<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
-									</value>
-								</nomatch>
+							<!-- Drape -> medieval room dividers as ALTERNATIVE, preserving each rank's drape count
+							     (VFEE escalates Drape 1->2->4->6; the old blanket replace flattened all to 1) -->
+							<li Class="PatchOperationSequence">
+								<operations>
+									<li Class="PatchOperationConditional">
+										<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=1]</xpath>
+										<match Class="PatchOperationReplace">
+											<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=1]</xpath>
+											<value>
+												<li Class="RoomRequirement_ThingAnyOfCount">
+													<things>
+														<li>Drape</li>
+														<li>DankPyon_RusticRoomDivider1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
+													</things>
+													<count>1</count>
+												</li>
+											</value>
+										</match>
+									</li>
+									<li Class="PatchOperationConditional">
+										<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=2]</xpath>
+										<match Class="PatchOperationReplace">
+											<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=2]</xpath>
+											<value>
+												<li Class="RoomRequirement_ThingAnyOfCount">
+													<things>
+														<li>Drape</li>
+														<li>DankPyon_RusticRoomDivider1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
+													</things>
+													<count>2</count>
+												</li>
+											</value>
+										</match>
+									</li>
+									<li Class="PatchOperationConditional">
+										<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=4]</xpath>
+										<match Class="PatchOperationReplace">
+											<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=4]</xpath>
+											<value>
+												<li Class="RoomRequirement_ThingAnyOfCount">
+													<things>
+														<li>Drape</li>
+														<li>DankPyon_RusticRoomDivider1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
+													</things>
+													<count>4</count>
+												</li>
+											</value>
+										</match>
+									</li>
+									<li Class="PatchOperationConditional">
+										<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=6]</xpath>
+										<match Class="PatchOperationReplace">
+											<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=6]</xpath>
+											<value>
+												<li Class="RoomRequirement_ThingAnyOfCount">
+													<things>
+														<li>Drape</li>
+														<li>DankPyon_RusticRoomDivider1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
+													</things>
+													<count>6</count>
+												</li>
+											</value>
+										</match>
+									</li>
+								</operations>
 							</li>
 														
 							<li Class="PatchOperationAdd">
@@ -563,6 +663,97 @@
 											<li>DankPyon_RusticHearth</li>
 										</things>
 										<count>1</count>
+									</li>
+								</value>
+							</li>
+
+							<!-- ===== VFEE higher-rank parity: medieval alternatives for VFEE-only items =====
+							     These rows only exist on the higher Empire titles (Archcount .. HighStellarch,
+							     incl. the 1.6 additions Magister & Despot) and on the abstract *Base titles they
+							     inherit from, so keying on the VFEE defName covers every higher rank at once. -->
+
+							<!-- VFEE_LargeRoyalRug (Archduke+) -> medieval royal rug alternative -->
+							<li Class="PatchOperationAdd">
+								<xpath>//RoyalTitleDef/bedroomRequirements/li[contains(., "VFEE_LargeRoyalRug")]/things</xpath>
+								<value>
+									<li>DankPyon_RugRoyal_LongLys2x4c</li>
+									<li>DankPyon_RugRoyal_LongLys3x3c</li>
+								</value>
+							</li>
+
+							<!-- VFEE_GrandRoyalRug (Consul+) -> medieval grand royal rug alternative -->
+							<li Class="PatchOperationAdd">
+								<xpath>//RoyalTitleDef/bedroomRequirements/li[contains(., "VFEE_GrandRoyalRug")]/things</xpath>
+								<value>
+									<li>DankPyon_RugRoyal_GrandCross3x3c</li>
+								</value>
+							</li>
+
+							<!-- Seat_RoyalArmchair (Despot+) -> medieval armchair alternatives -->
+							<li Class="PatchOperationAdd">
+								<xpath>//RoyalTitleDef/bedroomRequirements/li[contains(., "Seat_RoyalArmchair")]/things</xpath>
+								<value>
+									<li>DankPyon_RoyalArmchair</li>
+									<li>DankPyon_RusticNobleChair</li>
+								</value>
+							</li>
+
+							<!-- VFEE_Candelabra (Despot+, count 2) -> allow medieval candelabra, keep count -->
+							<li Class="PatchOperationReplace">
+								<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="VFEE_Candelabra"]</xpath>
+								<value>
+									<li Class="RoomRequirement_ThingAnyOfCount">
+										<things>
+											<li>VFEE_Candelabra</li>
+											<li>DankPyon_Candelabra</li>
+											<li>DankPyon_CandleStand</li>
+										</things>
+										<count>2</count>
+									</li>
+								</value>
+							</li>
+
+							<!-- VFEE_RoyalSculptureSmall (Despot count 1) -> allow medieval sculptures, keep count -->
+							<li Class="PatchOperationReplace">
+								<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="VFEE_RoyalSculptureSmall" and count=1]</xpath>
+								<value>
+									<li Class="RoomRequirement_ThingAnyOfCount">
+										<things>
+											<li>VFEE_RoyalSculptureSmall</li>
+											<li>DankPyon_Bust</li>
+											<li>DankPyon_ArchonSculpture2x2c</li>
+											<li>DankPyon_ArmorStatue</li>
+										</things>
+										<count>1</count>
+									</li>
+								</value>
+							</li>
+
+							<!-- VFEE_RoyalSculptureSmall (Stellarch+ count 2) -> allow medieval sculptures, keep count -->
+							<li Class="PatchOperationReplace">
+								<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="VFEE_RoyalSculptureSmall" and count=2]</xpath>
+								<value>
+									<li Class="RoomRequirement_ThingAnyOfCount">
+										<things>
+											<li>VFEE_RoyalSculptureSmall</li>
+											<li>DankPyon_Bust</li>
+											<li>DankPyon_ArchonSculpture2x2c</li>
+											<li>DankPyon_ArmorStatue</li>
+										</things>
+										<count>2</count>
+									</li>
+								</value>
+							</li>
+
+							<!-- VFEE_RoyalMirror (Marquess+) -> add gothic mirror alternative where that mod is present -->
+							<li Class="PatchOperationReplace">
+								<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_Thing" and thingDef="VFEE_RoyalMirror"]</xpath>
+								<value>
+									<li Class="RoomRequirement_ThingAnyOf">
+										<things>
+											<li>VFEE_RoyalMirror</li>
+											<li MayRequire="mingtuwuxiang.GothicDecorative">MUS_Gothicstyle_Mirror</li>
+										</things>
 									</li>
 								</value>
 							</li>
@@ -956,29 +1147,79 @@
 								</value>
 							</li>
 							
-							<li Class="PatchOperationConditional">
-								<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape"]</xpath>
-								<match Class="PatchOperationReplace">
-								<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape"]</xpath>
-									<value>
-										<li Class="RoomRequirement_ThingAnyOfCount">
-											<things>
-												<li>DankPyon_RusticRoomDivider1x2c</li>
-												<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
-												<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
-											</things>
-											<count>1</count>
-										</li>
-									</value>
-								</match>
-								<nomatch Class="PatchOperationAdd">
-									<xpath>//RoyalTitleDef/bedroomRequirements/li[contains(., "Drape")]/things</xpath>
-									<value>
-										<li>DankPyon_RusticRoomDivider1x2c</li>
-										<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
-										<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
-									</value>
-								</nomatch>
+							<!-- Drape -> medieval room dividers as ALTERNATIVE, preserving each rank's drape count
+							     (VFEE escalates Drape 1->2->4->6; the old blanket replace flattened all to 1) -->
+							<li Class="PatchOperationSequence">
+								<operations>
+									<li Class="PatchOperationConditional">
+										<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=1]</xpath>
+										<match Class="PatchOperationReplace">
+											<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=1]</xpath>
+											<value>
+												<li Class="RoomRequirement_ThingAnyOfCount">
+													<things>
+														<li>Drape</li>
+														<li>DankPyon_RusticRoomDivider1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
+													</things>
+													<count>1</count>
+												</li>
+											</value>
+										</match>
+									</li>
+									<li Class="PatchOperationConditional">
+										<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=2]</xpath>
+										<match Class="PatchOperationReplace">
+											<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=2]</xpath>
+											<value>
+												<li Class="RoomRequirement_ThingAnyOfCount">
+													<things>
+														<li>Drape</li>
+														<li>DankPyon_RusticRoomDivider1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
+													</things>
+													<count>2</count>
+												</li>
+											</value>
+										</match>
+									</li>
+									<li Class="PatchOperationConditional">
+										<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=4]</xpath>
+										<match Class="PatchOperationReplace">
+											<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=4]</xpath>
+											<value>
+												<li Class="RoomRequirement_ThingAnyOfCount">
+													<things>
+														<li>Drape</li>
+														<li>DankPyon_RusticRoomDivider1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
+													</things>
+													<count>4</count>
+												</li>
+											</value>
+										</match>
+									</li>
+									<li Class="PatchOperationConditional">
+										<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=6]</xpath>
+										<match Class="PatchOperationReplace">
+											<xpath>//RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingCount" and thingDef="Drape" and count=6]</xpath>
+											<value>
+												<li Class="RoomRequirement_ThingAnyOfCount">
+													<things>
+														<li>Drape</li>
+														<li>DankPyon_RusticRoomDivider1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Open1x2c</li>
+														<li>DankPyon_RusticThickRoomDivider_Closed1x2c</li>
+													</things>
+													<count>6</count>
+												</li>
+											</value>
+										</match>
+									</li>
+								</operations>
 							</li>
 							
 							<li Class="PatchOperationAdd">


### PR DESCRIPTION
Stacked on top of #2 (base = `claude/kabudan-big-threads-removal-267b03`).

## Problem
The 1.6 `EEG_RoyaltyTitle` integration in `Royalty_RoyalTitles_Empire.xml` only patches/escalates Empire bedrooms up to **Count**. The VFEE-specific higher ranks got the generic global furniture options, but their **VFEE-only requirement rows** were never made medieval-friendly, and the **Drape** requirement was flattened. This is the inconsistency reported on Steam (downgrade possible at Archcount+, "on/off makes no difference" for the progression).

Scope chosen: **parity / bugfix only** — no added difficulty.

## Changes (active+match / VFEE-present branch unless noted)
- **Drape count fix** — the blanket conditional replaced *every* rank's Drape with medieval dividers at a hard-coded `count=1`, discarding VFEE's per-rank escalation (1 → 2 → 4 → 6). Replaced with count-preserving conditionals (1/2/4/6) that keep `Drape` **and** offer the dividers as alternatives, so the original count (difficulty) is retained. Applied to all three branches for consistency.
- **VFEE_LargeRoyalRug / VFEE_GrandRoyalRug** → add `DankPyon` royal rug alternatives.
- **Seat_RoyalArmchair** → add `DankPyon_RoyalArmchair` / `DankPyon_RusticNobleChair`.
- **VFEE_Candelabra** (count 2) → allow `DankPyon_Candelabra` / `DankPyon_CandleStand`, count preserved.
- **VFEE_RoyalSculptureSmall** (count 1 Despot / 2 Stellarch+) → allow `DankPyon_Bust` / `ArchonSculpture` / `ArmorStatue`, count preserved per rank.
- **VFEE_RoyalMirror** → offer `MUS_Gothicstyle_Mirror` as alternative (`MayRequire`).

Keying on the VFEE defNames automatically covers **Magister & Despot** (new in VFEE 1.6) and the abstract `*Base` titles their variants inherit from — no per-rank blocks needed.

## Notes
- Verified well-formed XML (`xmllint`).
- The basic furniture (bed / end table / dresser / chest / hearth) already worked for these ranks via the global xpaths (because `Bed_AdvDoubleBed` contains the substring `DoubleBed`), so that part was *not* broken — only the items above.
- Requires a full RimWorld restart to re-run the PatchOperations (mod-setting changes don't re-patch live).
- Still open / out of scope: the `inactive`+VFEE-present branch is empty, so with the setting OFF + VFEE installed the title integration does nothing. Happy to address separately if you want.

https://claude.ai/code/session_01LdNCeGjBCM3X99taTAKwsg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdNCeGjBCM3X99taTAKwsg)_